### PR TITLE
added polar express in Muon for issue #11

### DIFF
--- a/configs/llm_config.py
+++ b/configs/llm_config.py
@@ -29,6 +29,7 @@ class BlueberryConfig:
     adamw_lr: float = 0.001
     warmup_ratio: float = 0.0
     schedule_type: str = "constant"
+    use_polar = True # if False will use Newton-Schulz in Muon
 
     # Evaluation
     eval_every: int = 2000

--- a/optimizers/muon.py
+++ b/optimizers/muon.py
@@ -1,6 +1,42 @@
 import torch
 import torch.nn.functional as F
 
+# coeffs for polar express 
+# not pre_computed, same as modded-nanoGPT 
+coeffs_list = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile()
+def zeropower_polar_express(G:torch.Tensor, steps: int = 5,):
+    """Polar express as replacement for Newton-Schulz iteration"""
+    assert G.ndim >= 2
+    assert steps <= len(coeffs_list)
+
+    X = G.bfloat16()
+    # X = G.half()
+
+    transpose_needed = G.size(-2) > G.size(-1) # transposing if tall matrix
+    if transpose_needed: 
+        X = X.mT 
+    
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.01 + 1e-7) # safety factor
+    
+    coeffs = coeffs_list[:steps]
+    for a , b, c in coeffs:
+        A = X @ X.mT 
+        A2 = A @ A 
+        B = b * A + c * A2
+        X = a * X + B @ X  # Right-multiplication for left polar factor
+    
+    if transpose_needed: 
+        X = X.mT 
+    
+    return X # orthogonalized 
 
 @torch.compile
 def zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5) -> torch.Tensor:
@@ -26,9 +62,9 @@ def zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5) -> torch.Tensor
 
 
 class Muon(torch.optim.Optimizer):
-    """Muon - MomentUm Orthogonalized by Newton-schulz"""
-    def __init__(self, params, lr=0.02, momentum=0.95, nesterov=True, ns_steps=5):
-        defaults = dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps)
+    """Muon - MomentUm Orthogonalized by Polar Express / Newton Schulz"""
+    def __init__(self, params, lr=0.02, momentum=0.95, nesterov=True, ns_steps=5, use_polar=False):
+        defaults = dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps, use_polar=use_polar)
         super().__init__(params, defaults)
 
     @torch.no_grad()
@@ -47,5 +83,10 @@ class Muon(torch.optim.Optimizer):
                 buf = state["momentum_buffer"]
                 buf.lerp_(g, 1 - group["momentum"])
                 g = g.lerp_(buf, group["momentum"]) if group["nesterov"] else buf
-                g = zeropower_via_newtonschulz5(g, steps=group["ns_steps"])
-                p.add_(g.view_as(p), alpha=-group["lr"] * max(1, p.size(-2) / p.size(-1))**0.5)
+                if group["use_polar"]:
+                    g = zeropower_polar_express(g, steps=group["ns_steps"]) # steps are 5 for both ns and pe
+                    g = g.to(p.dtype)
+                    p.add_(g.view_as(p), alpha=-group["lr"] * max(1, p.size(-2) / p.size(-1))**0.5)
+                else: 
+                    g = zeropower_via_newtonschulz5(g, steps=group["ns_steps"]) # steps are 5 for both ns and pe
+                    p.add_(g.view_as(p), alpha=-group["lr"] * max(1, p.size(-2) / p.size(-1))**0.5)

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -60,7 +60,7 @@ def setup_muon_optimizer(model: nn.Module, config: Blueberry80GBConfig):
     print(f"  Muon parameters: {sum(p.numel() for p in muon_params):,}")
     print(f"  AdamW parameters: {sum(p.numel() for p in adamw_params):,}")
 
-    muon_optimizer = Muon(muon_params, lr=config.muon_lr, momentum=config.muon_momentum)
+    muon_optimizer = Muon(muon_params, lr=config.muon_lr, momentum=config.muon_momentum, use_polar=config.use_polar)
     adamw_optimizer = torch.optim.AdamW(
         adamw_params,
         lr=config.adamw_lr,


### PR DESCRIPTION
Added

1.
```
@torch.compile()
def zeropower_polar_express(G:torch.Tensor, steps: int = 5,):
    """Polar express as replacement for Newton-Schulz iteration"""
    assert G.ndim >= 2
    assert steps <= len(coeffs_list)

    X = G.bfloat16()
    # X = G.half()

    transpose_needed = G.size(-2) > G.size(-1) # transposing if tall matrix
    if transpose_needed: 
        X = X.mT 
    
    X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.01 + 1e-7) # safety factor
    
    coeffs = coeffs_list[:steps]
    for a , b, c in coeffs:
        A = X @ X.mT 
        A2 = A @ A 
        B = b * A + c * A2
        X = a * X + B @ X  # Right-multiplication for left polar factor
    
    if transpose_needed: 
        X = X.mT 
    
    return X # orthogonalized 
```

2.   
`use_polar=True` in llm_config.py , if set to False Muon will use Newton-Schulz iteration else Polar Express

3. 
```
coeffs_list = [
    (8.156554524902461, -22.48329292557795, 15.878769915207462),
    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
]
```

This coefficents are not computed but was similiar to both the modded-nanoGPT and the original paper.


Not tested this due to compute issues. Colab free T4 has issues with bf16 and is not sufficient. wokring on getting more GPU.

my X account : [toheedakhtar01](https://x.com/ToheedAkhtar01) 